### PR TITLE
Adding api endpoints for orders -customer pov

### DIFF
--- a/Project/app/auth.py
+++ b/Project/app/auth.py
@@ -1,44 +1,85 @@
-import time, httpx, json
-from typing import Optional, Dict, Any
-from jose import jwt
-from fastapi import Depends, HTTPException, status, Header
+# app/auth.py
+import httpx
+from jose import jwt, JWTError
+from fastapi import Header, HTTPException
 from functools import lru_cache
+from typing import Any, Dict, Optional
 from .config import settings
 
+class AuthError(HTTPException):
+    def __init__(self, detail: str):
+        super().__init__(status_code=401, detail=detail)
+
 @lru_cache(maxsize=1)
-def _jwks_cache() -> Dict[str, Any]:
-    # simple cache; refresh process: restart or extend to timed cache
+def get_jwks() -> Dict[str, Any]:
+    if not settings.SUPABASE_JWKS_URL:
+        return {"keys": []}
     r = httpx.get(settings.SUPABASE_JWKS_URL, timeout=10.0)
     r.raise_for_status()
     return r.json()
 
-def _get_key_for_kid(kid: str):
-    jwks = _jwks_cache()
+def _decode_rs256(token: str) -> Dict[str, Any]:
+    jwks = get_jwks()
+    unverified = jwt.get_unverified_header(token)
+    kid = unverified.get("kid")
+    key = None
     for k in jwks.get("keys", []):
         if k.get("kid") == kid:
-            return k
-    return None
+            key = k
+            break
+    if not key:
+        raise AuthError("RS256: JWKS key not found for this token")
+    return jwt.decode(
+        token,
+        key,
+        algorithms=[key.get("alg", "RS256")],
+        options={"verify_aud": False},
+    )
 
-def _verify_jwt(token: str) -> Dict[str, Any]:
-    try:
-        headers = jwt.get_unverified_header(token)
-        key = _get_key_for_kid(headers["kid"])
-        if not key:
-            raise ValueError("JWKS key not found")
-        return jwt.decode(
-            token,
-            key,
-            algorithms=[key.get("alg","RS256")],
-            audience=None,  # set if you require
-            options={"verify_aud": False}
-        )
-    except Exception as e:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+def _decode_hs256(token: str) -> Dict[str, Any]:
+    if not settings.SUPABASE_JWT_SECRET:
+        raise AuthError("HS256: SUPABASE_JWT_SECRET not configured in .env")
+    return jwt.decode(
+        token,
+        settings.SUPABASE_JWT_SECRET,
+        algorithms=["HS256"],
+        options={"verify_aud": False},
+    )
 
 async def current_user(authorization: Optional[str] = Header(None)) -> Dict[str, Any]:
-    if not authorization or not authorization.lower().startswith("bearer "):
-        raise HTTPException(status_code=401, detail="Missing Bearer token")
-    token = authorization.split(" ", 1)[1]
-    claims = _verify_jwt(token)
-    # Basic shape: {'sub': '<user_uuid>', 'email': '...', 'role': 'authenticated', ...}
-    return {"user_id": claims.get("sub"), "email": claims.get("email")}
+    if not authorization:
+        raise AuthError("Missing Authorization header")
+    if not authorization.lower().startswith("bearer "):
+        raise AuthError("Authorization must be Bearer <token>")
+
+    token = authorization.split(" ", 1)[1].strip()
+
+    # 👉 basic JWT shape check
+    if token.count(".") != 2:
+        raise AuthError("Token is not in JWT format (expect 3 parts: header.payload.signature)")
+
+    # read alg from header
+    try:
+        unverified = jwt.get_unverified_header(token)
+    except JWTError as e:
+        # this is the exact error you’re seeing
+        raise AuthError(f"Invalid JWT header: {e}")
+
+    alg = unverified.get("alg")
+
+    if alg == "HS256":
+        claims = _decode_hs256(token)
+    elif alg == "RS256":
+        claims = _decode_rs256(token)
+    else:
+        raise AuthError(f"Unsupported alg: {alg}")
+
+    sub = claims.get("sub") or claims.get("user_id")
+    if not sub:
+        raise AuthError("Token decoded but no sub/user_id in payload")
+
+    return {
+        "id": sub,
+        "email": claims.get("email"),
+        "claims": claims,
+    }

--- a/Project/app/config.py
+++ b/Project/app/config.py
@@ -8,26 +8,28 @@ class Settings(BaseSettings):
     SUPABASE_URL: str
     SUPABASE_JWKS_URL: str
 
+    # add this 👇
+    SUPABASE_JWT_SECRET: Optional[str] = None
+
     SUPABASE_ANON_KEY: Optional[str] = None
+    SUPABASE_SERVICE_ROLE_KEY: Optional[str] = None
 
     ALLOWED_ORIGINS: List[str] = Field(default_factory=lambda: ["http://localhost:5173"])
 
-    # allow comma-separated list or JSON array in .env
     @field_validator("ALLOWED_ORIGINS", mode="before")
     @classmethod
     def parse_origins(cls, v):
         if isinstance(v, str):
             v = v.strip()
             if v.startswith("["):
-                return v  # let JSON parsing handle it
+                return v
             return [s.strip() for s in v.split(",") if s.strip()]
         return v
 
-    # pydantic v2 config
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
-        extra="ignore",  # <— ignore any other env vars you haven't declared
+        extra="ignore",
     )
 
 settings = Settings()

--- a/Project/app/db.py
+++ b/Project/app/db.py
@@ -1,7 +1,11 @@
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
 from .config import settings
 
-engine = create_async_engine(settings.DATABASE_URL, pool_pre_ping=True)
+engine = create_async_engine(
+    settings.DATABASE_URL,
+    pool_pre_ping=True,
+    connect_args={"ssl": "require"},  
+)
 SessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 
 async def get_db():

--- a/Project/app/main.py
+++ b/Project/app/main.py
@@ -1,13 +1,15 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from .config import settings
-from .routers import meals
+from .routers import meals, catalog, orders, debug_auth
+import sys
 
 # add this temporarily in app/main.py after imports
 import os
 print("CWD:", os.getcwd())
 from .config import settings
 print("DB URL present:", bool(settings.DATABASE_URL))
+print(">>> USING DATABASE_URL =", settings.DATABASE_URL, file=sys.stderr)
 
 app = FastAPI(title="VibeDish API", version="0.1.0")
 
@@ -24,3 +26,6 @@ async def health():
     return {"status": "ok"}
 
 app.include_router(meals.router, prefix="/meals", tags=["meals"])
+app.include_router(catalog.router, prefix="/catalog", tags=["catalog"])
+app.include_router(orders.router, prefix="/orders", tags=["orders"])
+app.include_router(debug_auth.router, prefix="/debug", tags=["debug"])

--- a/Project/app/routers/catalog.py
+++ b/Project/app/routers/catalog.py
@@ -1,0 +1,49 @@
+# app/routers/catalog.py
+from fastapi import APIRouter, Depends, Query, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import text
+from ..db import get_db
+
+router = APIRouter()
+
+@router.get("/restaurants")
+async def list_restaurants(
+    db: AsyncSession = Depends(get_db),
+    limit: int = Query(default=50, le=100),
+):
+    q = text("""
+        select id, name, address
+        from restaurants
+        order by created_at desc
+        limit :limit
+    """)
+    rows = (await db.execute(q, {"limit": limit})).mappings().all()
+    return [dict(r) for r in rows]
+
+@router.get("/meals")
+async def list_meals(
+    db: AsyncSession = Depends(get_db),
+    surplus_only: bool = Query(default=True),
+    restaurant_id: str | None = None,
+    limit: int = Query(default=50, le=100),
+):
+    base = """
+        select id, restaurant_id, name, tags, base_price, surplus_qty, surplus_price, allergens, calories
+        from meals
+        {where}
+        order by created_at desc
+        limit :limit
+    """
+    conds = []
+    params: dict = {"limit": limit}
+    if surplus_only:
+        conds.append("surplus_qty > 0")
+    if restaurant_id:
+        conds.append("restaurant_id = :rid")
+        params["rid"] = restaurant_id
+    where = ""
+    if conds:
+        where = "where " + " and ".join(conds)
+    q = text(base.format(where=where))
+    rows = (await db.execute(q, params)).mappings().all()
+    return [dict(r) for r in rows]

--- a/Project/app/routers/debug_auth.py
+++ b/Project/app/routers/debug_auth.py
@@ -1,0 +1,9 @@
+# app/routers/debug_auth.py
+from fastapi import APIRouter, Depends
+from ..auth import current_user
+
+router = APIRouter()
+
+@router.get("/me")
+async def whoami(user=Depends(current_user)):
+    return user

--- a/Project/app/routers/meals.py
+++ b/Project/app/routers/meals.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Depends, Query
+# app/routers/meals.py
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 from ..db import get_db
@@ -11,13 +12,18 @@ async def list_meals(
     limit: int = Query(default=50, le=100),
     db: AsyncSession = Depends(get_db),
 ):
-    q = """
-      select id, restaurant_id, name, tags, base_price, surplus_qty, surplus_price, allergens, calories
-      from meals
-      {where_clause}
-      order by created_at desc
-      limit :limit
-    """
-    where = "where surplus_qty > 0" if surplus_only else ""
-    rows = (await db.execute(text(q.format(where_clause=where)), {"limit": limit})).mappings().all()
-    return [dict(r) for r in rows]
+    try:
+        q = """
+          select id, restaurant_id, name, tags, base_price, surplus_qty, surplus_price, allergens, calories
+          from meals
+          {where_clause}
+          order by created_at desc
+          limit :limit
+        """
+        where = "where surplus_qty > 0" if surplus_only else ""
+        result = await db.execute(text(q.format(where_clause=where)), {"limit": limit})
+        rows = result.mappings().all()
+        return [dict(r) for r in rows]
+    except Exception as e:
+        # dev-friendly
+        raise HTTPException(status_code=500, detail=f"DB error: {e}")

--- a/Project/app/routers/orders.py
+++ b/Project/app/routers/orders.py
@@ -1,0 +1,227 @@
+# app/routers/orders.py
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import text
+from typing import List
+from ..db import get_db
+from ..auth import current_user
+
+router = APIRouter()
+
+@router.post("")
+async def create_order(
+    payload: dict,
+    db: AsyncSession = Depends(get_db),
+    user=Depends(current_user),
+):
+    """
+    Expects:
+    {
+      "restaurant_id": "...",
+      "items": [
+        {"meal_id": "...", "qty": 2},
+        ...
+      ]
+    }
+    - user_id is taken from token (customer)
+    - we will:
+      1) create order
+      2) for each item:
+         - check meal exists
+         - check surplus
+         - compute line price = surplus_price * qty
+         - decrement surplus
+      3) update order total
+    """
+    restaurant_id = payload.get("restaurant_id")
+    items: List[dict] = payload.get("items") or []
+    if not restaurant_id or not items:
+        raise HTTPException(status_code=400, detail="restaurant_id and items required")
+
+    # 1) create order (pending) for current user
+    create_order_q = text("""
+        insert into orders (user_id, restaurant_id, status, total)
+        values (:user_id, :restaurant_id, 'pending', 0)
+        returning id
+    """)
+    res = await db.execute(create_order_q, {
+        "user_id": user["id"],
+        "restaurant_id": restaurant_id,
+    })
+    order_row = res.mappings().first()
+    order_id = order_row["id"]
+
+    total = 0.0
+
+    for it in items:
+        meal_id = it.get("meal_id")
+        qty = int(it.get("qty", 0))
+        if not meal_id or qty <= 0:
+            raise HTTPException(status_code=400, detail="each item needs meal_id and positive qty")
+
+        # get meal info
+        meal_q = text("""
+            select id, surplus_qty, surplus_price, base_price
+            from meals
+            where id = :mid
+            for update
+        """)
+        meal_res = await db.execute(meal_q, {"mid": meal_id})
+        meal = meal_res.mappings().first()
+        if not meal:
+            raise HTTPException(status_code=404, detail=f"meal {meal_id} not found")
+        if meal["surplus_qty"] < qty:
+            raise HTTPException(status_code=400, detail=f"not enough surplus for meal {meal_id}")
+
+        line_price = float(meal["surplus_price"]) * qty
+        total += line_price
+
+        # insert order_item
+        insert_item_q = text("""
+            insert into order_items (order_id, meal_id, qty, price)
+            values (:order_id, :meal_id, :qty, :price)
+        """)
+        await db.execute(insert_item_q, {
+            "order_id": order_id,
+            "meal_id": meal_id,
+            "qty": qty,
+            "price": line_price,
+        })
+
+        # decrement surplus
+        update_meal_q = text("""
+            update meals
+            set surplus_qty = surplus_qty - :qty
+            where id = :mid
+        """)
+        await db.execute(update_meal_q, {"qty": qty, "mid": meal_id})
+
+    # update order total
+    upd_order_q = text("""
+        update orders
+        set total = :total
+        where id = :oid
+        returning id, user_id, restaurant_id, status, total, created_at
+    """)
+    final_res = await db.execute(upd_order_q, {
+        "total": total,
+        "oid": order_id,
+    })
+    final_order = final_res.mappings().first()
+
+    await db.commit()
+    return dict(final_order)
+
+
+@router.get("/mine")
+async def my_orders(
+    db: AsyncSession = Depends(get_db),
+    user=Depends(current_user),
+):
+    q = text("""
+        select o.id, o.restaurant_id, o.status, o.total, o.created_at,
+               r.name as restaurant_name
+        from orders o
+        join restaurants r on o.restaurant_id = r.id
+        where o.user_id = :uid
+        order by o.created_at desc
+        limit 50
+    """)
+    rows = (await db.execute(q, {"uid": user["id"]})).mappings().all()
+    return [dict(r) for r in rows]
+
+
+@router.get("/{order_id}")
+async def get_order(
+    order_id: str,
+    db: AsyncSession = Depends(get_db),
+    user=Depends(current_user),
+):
+    q = text("""
+        select o.id, o.user_id, o.restaurant_id, o.status, o.total, o.created_at,
+               r.name as restaurant_name
+        from orders o
+        join restaurants r on r.id = o.restaurant_id
+        where o.id = :oid
+    """)
+    res = await db.execute(q, {"oid": order_id})
+    row = res.mappings().first()
+    if not row:
+        raise HTTPException(status_code=404, detail="order not found")
+
+    # normalize ids
+    db_user_id = str(row["user_id"]).strip() if row["user_id"] is not None else ""
+    current_id = str(user["id"]).strip() if user.get("id") is not None else ""    
+
+    if db_user_id != current_id:
+        raise HTTPException(status_code=403, detail="not your order")
+
+    # fetch items
+    items_q = text("""
+        select oi.id, oi.meal_id, m.name as meal_name, oi.qty, oi.price
+        from order_items oi
+        join meals m on m.id = oi.meal_id
+        where oi.order_id = :oid
+        order by oi.id
+    """)
+    items_res = await db.execute(items_q, {"oid": order_id})
+    items = [dict(r) for r in items_res.mappings().all()]
+
+    return {
+        "order": dict(row),
+        "items": items,
+    }
+
+@router.patch("/{order_id}/cancel")
+async def cancel_order(
+    order_id: str,
+    db: AsyncSession = Depends(get_db),
+    user=Depends(current_user),
+):
+    # lock the order
+    order_q = text("""
+        select id, user_id, status
+        from orders
+        where id = :oid
+        for update
+    """)
+    order_res = await db.execute(order_q, {"oid": order_id})
+    order = order_res.mappings().first()
+    if not order:
+        raise HTTPException(status_code=404, detail="order not found")
+
+    db_user_id = str(order["user_id"]).strip() if order["user_id"] is not None else ""
+    current_id = str(user["id"]).strip() if user.get("id") is not None else ""
+
+    if db_user_id != current_id:
+        raise HTTPException(status_code=403, detail="not your order")
+
+    if order["status"] != "pending":
+        raise HTTPException(status_code=400, detail="cannot cancel after it is accepted")
+
+    # restore surplus
+    items_q = text("""
+        select meal_id, qty
+        from order_items
+        where order_id = :oid
+    """)
+    items_res = await db.execute(items_q, {"oid": order_id})
+    items = items_res.mappings().all()
+
+    for it in items:
+        upd_meal_q = text("""
+            update meals
+            set surplus_qty = surplus_qty + :qty
+            where id = :mid
+        """)
+        await db.execute(upd_meal_q, {"qty": it["qty"], "mid": it["meal_id"]})
+
+    upd_order_q = text("""
+        update orders
+        set status = 'cancelled'
+        where id = :oid
+    """)
+    await db.execute(upd_order_q, {"oid": order_id})
+
+    await db.commit()
+    return {"status": "cancelled", "order_id": order_id}

--- a/Project/app/scripts/make_token.py
+++ b/Project/app/scripts/make_token.py
@@ -1,0 +1,25 @@
+# scripts/make_token.py
+import os, time
+from jose import jwt
+from uuid import uuid4
+
+SECRET = os.getenv("SUPABASE_JWT_SECRET")
+if not SECRET:
+    raise SystemExit("SUPABASE_JWT_SECRET not set in env/.env")
+
+now=int(time.time())
+
+# you can pass USER_ID=... and EMAIL=...
+user_id=os.getenv("USER_ID") or str(uuid4())
+email=os.getenv("EMAIL") or "devuser@example.com"
+
+payload={
+    "sub":user_id,
+    "email":email,
+    "role":"authenticated",
+    "iat":now,
+    "exp":now+3600  # 1 hr
+}
+
+token=jwt.encode(payload,SECRET,algorithm="HS256")
+print(token)

--- a/Project/requirements.txt
+++ b/Project/requirements.txt
@@ -1,0 +1,9 @@
+databases==0.9.0
+fastapi==0.120.4
+httpx==0.28.1
+"python-jose[cryptography]"
+pydantic==2.12.3
+pydantic_settings==2.11.0
+python-dotenv==1.2.1
+Requests==2.32.5
+SQLAlchemy==2.0.25


### PR DESCRIPTION
Added api endpoints for placing orders, order list, and cancelling pending orders

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds customer order APIs to place orders, view your orders, and cancel pending orders. Also adds catalog endpoints and updates auth to support HS256 and RS256 JWTs.

- **New Features**
  - Orders: POST /orders, GET /orders/mine, GET /orders/{id}, PATCH /orders/{id}/cancel with surplus checks, totals, and owner-only access.
  - Catalog: GET /catalog/restaurants and GET /catalog/meals (surplus_only and restaurant filters).
  - Auth: HS256 and RS256 JWT support; /debug/me for quick token verification.
  - App: Routers wired in main; DB connection now requires SSL.

- **Migration**
  - Set SUPABASE_JWT_SECRET in .env for HS256; keep SUPABASE_JWKS_URL for RS256.
  - Install new packages from requirements.txt.
  - Optional: use scripts/make_token.py to generate a local dev token.

<sup>Written for commit 397f7b509b2377d82ebd47dbe83c4ce3f70e581f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

