### PR TITLE
small fix for the address module

### DIFF
--- a/Project/app/main.py
+++ b/Project/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from .config import settings
-from .routers import meals, catalog, orders, debug_auth, auth_routes, me, addresses
+from .routers import meals, catalog, orders, debug_auth, auth_routes, me, address
 import sys
 
 app = FastAPI(title="VibeDish API", version="0.1.0")
@@ -20,7 +20,7 @@ async def health():
 
 app.include_router(auth_routes.router)
 app.include_router(me.router)
-app.include_router(addresses.router)
+app.include_router(address.router)
 app.include_router(meals.router, prefix="/meals", tags=["meals"])
 app.include_router(catalog.router, prefix="/catalog", tags=["catalog"])
 app.include_router(orders.router, prefix="/orders", tags=["orders"])


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix address router import to use address instead of addresses. Prevents import errors and ensures address endpoints are registered.

<sup>Written for commit 877bd1a6216ac6cf5d4df524cdd0ef7c7d33eeb2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

