### PR TITLE
Added order timelines for tracking and also added the ability to cancel orders

### DIFF
--- a/Project/app/routers/orders.py
+++ b/Project/app/routers/orders.py
@@ -1,24 +1,50 @@
 # app/routers/orders.py
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import text
-from typing import List
+from typing import List, Dict, Any
 from ..db import get_db
 from ..auth import current_user
 
 router = APIRouter()
 
+# ---- helpers ---------------------------------------------------------------
+
+async def _append_status_event(db: AsyncSession, order_id: str, status: str):
+    ins = text("""
+        INSERT INTO order_status_events (order_id, status)
+        VALUES (CAST(:oid AS uuid), CAST(:status AS order_status))
+    """)
+    await db.execute(ins, {"oid": order_id, "status": status})
+
+
+
+# ---- routes ----------------------------------------------------------------
+
 @router.post("")
 async def create_order(
-    payload: dict,
+    payload: Dict[str, Any],
     db: AsyncSession = Depends(get_db),
     user=Depends(current_user),
 ):
+    """
+    Body:
+    {
+      "restaurant_id": "<uuid>",
+      "items": [{"meal_id":"<uuid>", "qty": 2}, ...]
+    }
+    Behavior:
+      - Creates order (pending)
+      - Validates meals + surplus, inserts order_items, decrements surplus
+      - Updates order total
+      - Logs a 'pending' status event
+    """
     restaurant_id = payload.get("restaurant_id")
     items: List[dict] = payload.get("items") or []
     if not restaurant_id or not items:
         raise HTTPException(status_code=400, detail="restaurant_id and items required")
 
+    # 1) create order shell
     create_order_q = text("""
         insert into orders (user_id, restaurant_id, status, total)
         values (:user_id, :restaurant_id, 'pending', 0)
@@ -28,16 +54,30 @@ async def create_order(
         "user_id": str(user["id"]).strip(),
         "restaurant_id": restaurant_id,
     })
-    order_id = res.mappings().first()["id"]
+    order_row = res.mappings().first()
+    if not order_row:
+        raise HTTPException(status_code=500, detail="failed to create order")
+    order_id = order_row["id"]
 
+    # Log initial status
+    await _append_status_event(db, order_id, "pending")
+
+    # 2) process items
     total = 0.0
-
     for it in items:
         meal_id = it.get("meal_id")
-        qty = int(it.get("qty", 0))
-        if not meal_id or qty <= 0:
-            raise HTTPException(status_code=400, detail="each item needs meal_id and positive qty")
+        try:
+            qty = int(it.get("qty", 0))
+        except Exception:
+            qty = 0
 
+        if not meal_id or qty <= 0:
+            raise HTTPException(
+                status_code=400,
+                detail="each item needs meal_id and positive qty"
+            )
+
+        # lock row to keep surplus consistent
         meal_q = text("""
             select id, surplus_qty, surplus_price, base_price
             from meals
@@ -48,12 +88,13 @@ async def create_order(
         meal = meal_res.mappings().first()
         if not meal:
             raise HTTPException(status_code=404, detail=f"meal {meal_id} not found")
-        if meal["surplus_qty"] < qty:
+        if (meal["surplus_qty"] or 0) < qty:
             raise HTTPException(status_code=400, detail=f"not enough surplus for meal {meal_id}")
 
         line_price = float(meal["surplus_price"]) * qty
         total += line_price
 
+        # add order item
         insert_item_q = text("""
             insert into order_items (order_id, meal_id, qty, price)
             values (:order_id, :meal_id, :qty, :price)
@@ -65,6 +106,7 @@ async def create_order(
             "price": line_price,
         })
 
+        # decrement surplus
         update_meal_q = text("""
             update meals
             set surplus_qty = surplus_qty - :qty
@@ -72,33 +114,37 @@ async def create_order(
         """)
         await db.execute(update_meal_q, {"qty": qty, "mid": meal_id})
 
+    # 3) finalize order total and return
     upd_order_q = text("""
         update orders
         set total = :total
         where id = :oid
         returning id, user_id, restaurant_id, status, total, created_at
     """)
-    final_res = await db.execute(upd_order_q, {
-        "total": total,
-        "oid": order_id,
-    })
+    final_res = await db.execute(upd_order_q, {"total": total, "oid": order_id})
+    final_row = final_res.mappings().first()
     await db.commit()
-    return dict(final_res.mappings().first())
+    return dict(final_row)
 
 
 @router.get("/mine")
 async def list_my_orders(
     db: AsyncSession = Depends(get_db),
     user=Depends(current_user),
+    limit: int = Query(default=50, le=100),
 ):
+    """
+    List current user's orders newest-first.
+    """
     user_id = str(user["id"]).strip()
     q = text("""
         select id, restaurant_id, status, total, created_at
         from orders
         where user_id = :uid
         order by created_at desc
+        limit :limit
     """)
-    res = await db.execute(q, {"uid": user_id})
+    res = await db.execute(q, {"uid": user_id, "limit": limit})
     rows = [dict(r) for r in res.mappings().all()]
     return rows
 
@@ -109,6 +155,9 @@ async def get_order(
     db: AsyncSession = Depends(get_db),
     user=Depends(current_user),
 ):
+    """
+    Get a single order (must be owned by current user).
+    """
     q = text("""
         select o.id, o.user_id, o.restaurant_id, o.status, o.total, o.created_at,
                r.name as restaurant_name
@@ -123,7 +172,6 @@ async def get_order(
 
     db_user_id = str(row["user_id"]).strip() if row["user_id"] is not None else ""
     current_id = str(user["id"]).strip() if user.get("id") is not None else ""
-
     if db_user_id != current_id:
         raise HTTPException(status_code=403, detail="not your order")
 
@@ -143,12 +191,50 @@ async def get_order(
     }
 
 
+@router.get("/{order_id}/status")
+async def get_order_status_timeline(
+    order_id: str,
+    db: AsyncSession = Depends(get_db),
+    user=Depends(current_user),
+):
+    """
+    Returns the chronological status timeline for an order (user must own the order).
+    """
+    # validate ownership
+    own_q = text("select user_id from orders where id = :oid")
+    own_res = await db.execute(own_q, {"oid": order_id})
+    own = own_res.mappings().first()
+    if not own:
+        raise HTTPException(status_code=404, detail="order not found")
+
+    db_user_id = str(own["user_id"]).strip() if own["user_id"] is not None else ""
+    current_id = str(user["id"]).strip() if user.get("id") is not None else ""
+    if db_user_id != current_id:
+        raise HTTPException(status_code=403, detail="not your order")
+
+    # fetch events
+    ev_q = text("""
+        select status, created_at
+        from order_status_events
+        where order_id = :oid
+        order by created_at asc
+    """)
+    ev_res = await db.execute(ev_q, {"oid": order_id})
+    events = [dict(r) for r in ev_res.mappings().all()]
+    return {"order_id": order_id, "timeline": events}
+
+
 @router.patch("/{order_id}/cancel")
 async def cancel_order(
     order_id: str,
     db: AsyncSession = Depends(get_db),
     user=Depends(current_user),
 ):
+    """
+    Cancel an order you own (only when status is 'pending').
+    Restores meal surplus and logs a 'cancelled' status event.
+    """
+    # lock the order row
     order_q = text("""
         select id, user_id, status
         from orders
@@ -162,22 +248,20 @@ async def cancel_order(
 
     db_user_id = str(order["user_id"]).strip() if order["user_id"] is not None else ""
     current_id = str(user["id"]).strip() if user.get("id") is not None else ""
-
     if db_user_id != current_id:
         raise HTTPException(status_code=403, detail="not your order")
 
     if order["status"] != "pending":
         raise HTTPException(status_code=400, detail="cannot cancel after it is accepted")
 
+    # restore surplus for each item
     items_q = text("""
         select meal_id, qty
         from order_items
         where order_id = :oid
     """)
     items_res = await db.execute(items_q, {"oid": order_id})
-    items = items_res.mappings().all()
-
-    for it in items:
+    for it in items_res.mappings().all():
         upd_meal_q = text("""
             update meals
             set surplus_qty = surplus_qty + :qty
@@ -185,12 +269,14 @@ async def cancel_order(
         """)
         await db.execute(upd_meal_q, {"qty": it["qty"], "mid": it["meal_id"]})
 
+    # set order status + log event
     upd_order_q = text("""
         update orders
         set status = 'cancelled'
         where id = :oid
     """)
     await db.execute(upd_order_q, {"oid": order_id})
+    await _append_status_event(db, order_id, "cancelled")
 
     await db.commit()
     return {"status": "cancelled", "order_id": order_id}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds status timelines for orders and lets users cancel pending orders. Improves consistency by logging status changes and restoring meal surplus on cancellation.

- **New Features**
  - GET /orders/{order_id}/status returns a chronological status timeline (ownership enforced).
  - PATCH /orders/{order_id}/cancel allows cancelling only pending orders, restores meal surplus, and logs a "cancelled" event.
  - Order creation now logs an initial "pending" status event.
  - GET /orders/mine supports a limit query param (default 50, max 100), ordered newest-first.

<sup>Written for commit 6ba1cb9c7e4296cbe6c57710e2b2b0f63b81c18b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

