### PR TITLE
added endpoints to facilitate logout and delete the user

### DIFF
--- a/Project/app/config.py
+++ b/Project/app/config.py
@@ -1,35 +1,66 @@
 # app/config.py
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 from typing import List, Optional
 
+
 class Settings(BaseSettings):
-    DATABASE_URL: str
-    SUPABASE_URL: str
-    SUPABASE_JWKS_URL: str
+    # Required
+    DATABASE_URL: str        # e.g., postgresql://user:pass@localhost:5432/db
+    SUPABASE_URL: str        # e.g., https://your-project.supabase.co
 
-    # add this 👇
+    # Optional auth bits
+    SUPABASE_JWKS_URL: Optional[str] = None   # derived if not provided
     SUPABASE_JWT_SECRET: Optional[str] = None
-
     SUPABASE_ANON_KEY: Optional[str] = None
     SUPABASE_SERVICE_ROLE_KEY: Optional[str] = None
 
-    ALLOWED_ORIGINS: List[str] = Field(default_factory=lambda: ["http://localhost:5173"])
+    # CORS
+    ALLOWED_ORIGINS: List[str] = Field(
+        default_factory=lambda: ["http://localhost:5173"]
+    )
 
+    # Derived (not read from env)
+    ASYNC_DATABASE_URL: Optional[str] = None  # computed from DATABASE_URL
+
+    # Parse comma/JSON string into list for ALLOWED_ORIGINS
     @field_validator("ALLOWED_ORIGINS", mode="before")
     @classmethod
     def parse_origins(cls, v):
         if isinstance(v, str):
             v = v.strip()
+            # allow JSON-style ["...","..."]
             if v.startswith("["):
                 return v
+            # allow comma-separated
             return [s.strip() for s in v.split(",") if s.strip()]
         return v
+
+    @model_validator(mode="after")
+    def _derive_fields(self):
+        # Normalize SUPABASE_URL (strip trailing slash)
+        self.SUPABASE_URL = self.SUPABASE_URL.rstrip("/")
+
+        # Derive JWKS URL if not provided
+        if not self.SUPABASE_JWKS_URL:
+            self.SUPABASE_JWKS_URL = f"{self.SUPABASE_URL}/auth/v1/keys"
+
+        # Build an async URL for SQLAlchemy if needed
+        url = self.DATABASE_URL
+        if url.startswith("postgres://"):
+            # old Heroku-style -> proper driver prefix
+            url = "postgresql://" + url[len("postgres://"):]
+        if url.startswith("postgresql://") and "+asyncpg" not in url:
+            url = "postgresql+asyncpg://" + url[len("postgresql://"):]
+        self.ASYNC_DATABASE_URL = url
+
+        return self
 
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
         extra="ignore",
     )
+
 
 settings = Settings()

--- a/Project/app/db.py
+++ b/Project/app/db.py
@@ -4,7 +4,9 @@ from .config import settings
 engine = create_async_engine(
     settings.DATABASE_URL,
     pool_pre_ping=True,
-    connect_args={"ssl": "require"},  
+    connect_args={"ssl": "require"}, 
+    future=True,
+    echo=False 
 )
 SessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 

--- a/Project/app/routers/auth_routes.py
+++ b/Project/app/routers/auth_routes.py
@@ -1,16 +1,22 @@
 # app/routers/auth_routes.py
 import httpx
-from fastapi import APIRouter, HTTPException, status, Depends
+from fastapi import APIRouter, HTTPException, status, Depends, Header
 from pydantic import BaseModel, EmailStr
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import text
+from typing import Optional
+
 from ..config import settings
 from ..db import get_db
-from ..auth import ensure_app_user
+from ..auth import current_user  # validate JWT & provide user dict
+
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
+# =========================
+# Schemas
+# =========================
 class LoginRequest(BaseModel):
     email: EmailStr
     password: str
@@ -22,137 +28,185 @@ class SignupRequest(BaseModel):
     name: str
 
 
-@router.post("/login")
-async def login(payload: LoginRequest, db: AsyncSession = Depends(get_db)):
-    email=payload.email
-    password=payload.password
-    if not email or not password:
-        raise HTTPException(status_code=400, detail="email and password required")
+class RefreshRequest(BaseModel):
+    refresh_token: str
 
-    # 1) hit supabase auth
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        r=await client.post(
-            f"{settings.SUPABASE_URL}/auth/v1/token?grant_type=password",
-            headers={
-                "apikey": settings.SUPABASE_ANON_KEY,
-                "Authorization": f"Bearer {settings.SUPABASE_ANON_KEY}",
-                "Content-Type": "application/json",
-            },
-            json={"email": email, "password": password},
+
+# =========================
+# Helpers
+# =========================
+async def ensure_app_user(
+    db: AsyncSession,
+    *,
+    user_id: str,
+    email: str,
+    name: Optional[str] = None,
+) -> None:
+    """Make sure a Supabase user exists in local app DB and keep minimal fields in sync."""
+    # 1) try by id
+    q_by_id = text("select id from users where id=:uid")
+    row = (await db.execute(q_by_id, {"uid": user_id})).mappings().first()
+    if row:
+        upd = text(
+            """
+            update users
+            set email=:email,
+                name = coalesce(:name, name)
+            where id=:uid
+            """
         )
+        await db.execute(upd, {"uid": user_id, "email": email, "name": name})
+        return
 
-    if r.status_code >= 400:
-        # try to show the real supabase error
-        try:
-            err = r.json()
-        except Exception:
-            err = {"message": r.text}
-        raise HTTPException(
-            status_code=400,
-            detail={"from":"supabase","status":r.status_code, **err},
+    # 2) try by email (older records before Supabase sync)
+    q_by_email = text("select id from users where email=:email")
+    row2 = (await db.execute(q_by_email, {"email": email})).mappings().first()
+    if row2:
+        upd = text(
+            """
+            update users
+            set id=:uid,
+                name = coalesce(:name, name)
+            where email=:email
+            """
         )
+        await db.execute(upd, {"uid": user_id, "email": email, "name": name})
+        return
 
-    token_data = r.json()
-    access_token = token_data["access_token"]
-
-    # 2) fetch /user from supabase
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        me = await client.get(
-            f"{settings.SUPABASE_URL}/auth/v1/user",
-            headers={
-                "apikey": settings.SUPABASE_ANON_KEY,
-                "Authorization": f"Bearer {access_token}",
-            },
-        )
-
-    if me.status_code >= 400:
-        raise HTTPException(status_code=400, detail="could not fetch user from supabase")
-
-    me_data = me.json()
-    user_id = me_data["id"]
-    user_email = me_data["email"]
-    user_name = me_data.get("user_metadata", {}).get("name")
-
-    # 3) ensure local user
-    await ensure_app_user(
-        db,
-        user_id=user_id,
-        email=user_email,
-        name=user_name,
+    # 3) neither exists → insert
+    ins = text(
+        """
+        insert into users (id, email, name, role)
+        values (:uid, :email, :name, 'customer')
+        """
     )
-    await db.commit()
-
-    return {
-        "access_token": access_token,
-        "token_type": "bearer",
-        "refresh_token": token_data.get("refresh_token"),
-        "user": {
-            "id": user_id,
-            "email": user_email,
-            "name": user_name,
-        },
-    }
+    await db.execute(ins, {"uid": user_id, "email": email, "name": name})
 
 
+def _extract_bearer_token(authorization: Optional[str]) -> str:
+    if not authorization or not authorization.lower().startswith("bearer "):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="missing bearer token")
+    return authorization.split(" ", 1)[1].strip()
 
+
+# =========================
+# Auth endpoints
+# =========================
 @router.post("/signup")
 async def signup(payload: SignupRequest, db: AsyncSession = Depends(get_db)):
     # Step 1 – sign up via Supabase Auth
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=10.0) as client:
         r = await client.post(
             f"{settings.SUPABASE_URL}/auth/v1/signup",
             headers={
-                "apikey": settings.SUPABASE_ANON_KEY,
+                "apikey": settings.SUPABASE_ANON_KEY or "",
                 "Content-Type": "application/json",
             },
             json={"email": payload.email, "password": payload.password, "data": {"name": payload.name}},
         )
     if r.status_code >= 400:
-        raise HTTPException(status_code=400, detail=r.json())
-    data = r.json()
+        # Pass through Supabase error to caller
+        try:
+            err = r.json()
+        except Exception:
+            err = {"message": r.text}
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=err)
 
-    user_id = data["id"]
-    user_email = data["email"]
+    data = r.json()
+    # Sign-up response may return either {user: {...}} or flat fields depending on GoTrue version
+    user_id = data.get("id") or (data.get("user") or {}).get("id")
+    user_email = data.get("email") or (data.get("user") or {}).get("email")
+
+    if not user_id or not user_email:
+        raise HTTPException(status_code=500, detail="unexpected signup response from auth provider")
 
     # Step 2 – mirror into your app DB with the user’s name
-    ins = text("""
+    ins = text(
+        """
         insert into users (id, email, name, role)
         values (:uid, :email, :name, 'customer')
         on conflict (id) do update
-        set name = excluded.name, email = excluded.email;
-    """)
+        set name = excluded.name, email = excluded.email
+        """
+    )
     await db.execute(ins, {"uid": user_id, "email": user_email, "name": payload.name})
     await db.commit()
 
     return {"id": user_id, "email": user_email, "name": payload.name}
 
 
+@router.post("/login")
+async def login(payload: LoginRequest, db: AsyncSession = Depends(get_db)):
+    email = payload.email
+    password = payload.password
+    if not email or not password:
+        raise HTTPException(status_code=400, detail="email and password required")
 
+    # 1) password grant → get tokens
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        r = await client.post(
+            f"{settings.SUPABASE_URL}/auth/v1/token?grant_type=password",
+            headers={
+                "apikey": settings.SUPABASE_ANON_KEY or "",
+                "Content-Type": "application/json",
+            },
+            json={"email": email, "password": password},
+        )
+    if r.status_code >= 400:
+        raise HTTPException(status_code=400, detail="invalid credentials")
 
-class RefreshRequest(BaseModel):
-    refresh_token: str
+    token_data = r.json()  # access_token, refresh_token, token_type, user (maybe)
+    access_token = token_data.get("access_token")
+    if not access_token:
+        raise HTTPException(status_code=400, detail="invalid credentials")
+
+    # 2) fetch user (confirm id/email)
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        me = await client.get(
+            f"{settings.SUPABASE_URL}/auth/v1/user",
+            headers={
+                "apikey": settings.SUPABASE_ANON_KEY or "",
+                "Authorization": f"Bearer {access_token}",
+            },
+        )
+    if me.status_code >= 400:
+        raise HTTPException(status_code=400, detail="could not fetch user from supabase")
+
+    me_data = me.json()
+    user_id = me_data.get("id")
+    user_email = me_data.get("email")
+    user_name = (me_data.get("user_metadata") or {}).get("name")
+
+    if not user_id or not user_email:
+        raise HTTPException(status_code=400, detail="invalid user data from auth provider")
+
+    # 3) ensure local user row
+    await ensure_app_user(db, user_id=user_id, email=user_email, name=user_name)
+    await db.commit()
+
+    # 4) response for frontend
+    return {
+        "access_token": access_token,
+        "token_type": token_data.get("token_type", "bearer"),
+        "refresh_token": token_data.get("refresh_token"),
+        "user": {"id": user_id, "email": user_email, "name": user_name},
+    }
 
 
 @router.post("/refresh")
 async def refresh_token(body: RefreshRequest):
-    """
-    Exchange refresh_token -> new access_token
-    """
+    """Exchange refresh_token → new access_token using Supabase GoTrue."""
     supabase_refresh_url = f"{settings.SUPABASE_URL}/auth/v1/token?grant_type=refresh_token"
-
     headers = {
-        "apikey": settings.SUPABASE_ANON_KEY,
+        "apikey": settings.SUPABASE_ANON_KEY or "",
         "Content-Type": "application/json",
     }
 
     async with httpx.AsyncClient(timeout=10.0) as client:
-        r = await client.post(
-            supabase_refresh_url,
-            headers=headers,
-            json={"refresh_token": body.refresh_token},
-        )
+        r = await client.post(supabase_refresh_url, headers=headers, json={"refresh_token": body.refresh_token})
 
     if r.status_code != 200:
+        # surface upstream error
         try:
             err = r.json()
         except Exception:
@@ -164,3 +218,78 @@ async def refresh_token(body: RefreshRequest):
 
     return r.json()
 
+
+@router.post("/logout")
+async def logout(authorization: Optional[str] = Header(None)):
+    """
+    Invalidate the current session with Supabase. We don't need DB here.
+    Requires the Authorization: Bearer <access_token> header.
+    """
+    access_token = _extract_bearer_token(authorization)
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        r = await client.post(
+            f"{settings.SUPABASE_URL}/auth/v1/logout",
+            headers={
+                "apikey": settings.SUPABASE_ANON_KEY or "",
+                "Authorization": f"Bearer {access_token}",
+            },
+        )
+
+    # GoTrue often returns 200 or 204; treat 401 as already invalidated
+    if r.status_code in (200, 204, 401):
+        return {"ok": True}
+    try:
+        err = r.json()
+    except Exception:
+        err = {"message": r.text}
+    raise HTTPException(status_code=r.status_code, detail=err)
+
+
+@router.delete("/me")
+async def delete_me(
+    db: AsyncSession = Depends(get_db),
+    user=Depends(current_user),  # validated, gives {"id": "...", "email": ...}
+):
+    """
+    Permanently delete the current user:
+      1) Delete local rows (users) – rely on ON DELETE CASCADE for related tables if set.
+      2) Delete Supabase user via Admin API (requires service role key).
+    """
+    uid = str(user["id"]).strip()
+
+    # 1) delete local user (best-effort)
+    try:
+        await db.execute(text("delete from users where id = :uid"), {"uid": uid})
+        await db.commit()
+    except Exception:
+        # don't block admin delete if local delete fails
+        await db.rollback()
+
+    # 2) Supabase admin delete (requires service role)
+    if not settings.SUPABASE_SERVICE_ROLE_KEY:
+        # If no service key, we can't remove the auth identity; inform caller.
+        return {
+            "deleted_in_app_db": True,
+            "deleted_in_supabase": False,
+            "note": "Missing SUPABASE_SERVICE_ROLE_KEY; only local data was removed.",
+        }
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        r = await client.delete(
+            f"{settings.SUPABASE_URL}/auth/v1/admin/users/{uid}",
+            headers={
+                "apikey": settings.SUPABASE_SERVICE_ROLE_KEY,
+                "Authorization": f"Bearer {settings.SUPABASE_SERVICE_ROLE_KEY}",
+            },
+        )
+
+    if r.status_code in (200, 204):
+        return {"deleted_in_app_db": True, "deleted_in_supabase": True}
+
+    # If Supabase deletion failed, surface error but keep local deletion result.
+    try:
+        err = r.json()
+    except Exception:
+        err = {"message": r.text}
+    raise HTTPException(status_code=r.status_code, detail=err)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added two auth endpoints for logout and account deletion, with Supabase integration, and tightened auth/config handling for more reliable sessions and user sync.

- **New Features**
  - POST /auth/logout invalidates the current Supabase session (Bearer token required).
  - DELETE /auth/me removes the user in the app DB and, if a service role key is set, deletes the Supabase user.

- **Refactors**
  - Hardened signup/login/refresh flows with clearer errors and user syncing via ensure_app_user.
  - Normalized SUPABASE_URL, auto-derived JWKS URL, and improved CORS origins parsing (comma or JSON).
  - Derived ASYNC_DATABASE_URL for Postgres; tuned the async engine (future=True, echo=False).

<sup>Written for commit 25aa0bc01c3cbd59b88d42d2bcf9ecad22d5babe. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

